### PR TITLE
Update satwnd

### DIFF
--- a/src/bufr_aircar2ob.f
+++ b/src/bufr_aircar2ob.f
@@ -9,7 +9,7 @@
      +                  r8arr3 ( MXMN, MXLV ), r8arr4(MXMN, MXLV ) 
 
         PARAMETER       ( MXBF = 16000 )
-        PARAMETER       (iu=9,iou=10,nz=999999)
+        PARAMETER       (iu=9,iou=10,nz=9999999)
  
         dimension pr(nz),tt(nz),td(nz)         
 

--- a/src/bufr_craft2ob.f
+++ b/src/bufr_craft2ob.f
@@ -11,7 +11,7 @@
 
         PARAMETER       ( MXBF = 16000 )
 
-        parameter(iu=9,iou=10,nz=999999)
+        parameter(iu=9,iou=10,nz=9999999)
 
         dimension pr(nz),tt(nz),td(nz),zx1(nz),zx2(nz)
 

--- a/src/bufr_upa2ob.f
+++ b/src/bufr_upa2ob.f
@@ -10,7 +10,7 @@
 
         PARAMETER       ( MXBF = 16000 )
 
-        parameter(iu=9,iou=10,nz=999999)
+        parameter(iu=9,iou=10,nz=9999999)
         dimension pr(nz),tt(nz),td(nz)
         integer  xht,nlev,i, iargc, n,minu,k
         real  xu,xv,xy,xm,xh,xmm,xd

--- a/src/decode_satwnd.f
+++ b/src/decode_satwnd.f
@@ -1,0 +1,246 @@
+        PARAMETER       ( MXMN = 8 )
+        PARAMETER       ( MXLV = 220 )
+        PARAMETER       ( NVAR = 17 )
+        PARAMETER       ( NSTR = 4 )
+
+        COMMON /BITBUF/ MAXBYT,IBIT,IBAY(5000),MBYT(32),MBAY(5000,32)
+
+        REAL*8          r8arr ( MXMN, MXLV ), r8arr2(MXMN, MXLV ),
+     +                  r8arr3 ( MXMN, MXLV ), r8arr4(MXMN, MXLV ) 
+
+        PARAMETER       ( MXBF = 16000 )
+
+        parameter(iu=9,iou=10,nz=999999)
+
+        dimension pr(nz),tt(nz),td(nz)
+        integer  xht,nlev,i, iargc, n,minu,k
+        real  xpr,xu,xv
+        real  temp,v(nz),zx(nz),d(nz)
+        real  lat(nz), lon(nz)
+        real xt,xtd
+        character*30 fin,fout
+        character*10  date_tag,date(nz)
+        character*6 dname
+        character   argv*300,minute*2,M11*2,mins(nz)*2
+        character*12 ilev
+        character*12 M10,M1,M2,M3,M4,M5,M6
+        real wlon,elon,slat,nlat
+
+        CHARACTER       cbfmsg*(MXBF),
+     +                  csubset*8, inf*200, outstg*200
+
+        CHARACTER*80   ostr(NSTR)
+
+        INTEGER         ibfmsg ( MXBF / 4 ), ln, code,y,z,idate
+
+        LOGICAL         msgok
+
+        EQUIVALENCE     ( cbfmsg (1), ibfmsg (1) )
+
+        ostr(1)='SAID GCLONG SCLF RPID'
+        ostr(2)='SIDP SWCM YEAR MNTH DAYS'
+        ostr(3)='HOUR MINU CLAT CLON'
+        ostr(4)='TMDBST PRLC WDIR WSPD'
+
+C*-----------------------------------------------------------------------
+c*    Read the command-line arguments
+c*      
+        n = iargc()
+        IF (n .GE. 2) THEN
+          call getarg( 1, argv )
+          inf=argv
+          call getarg(2,argv)
+          date_tag=argv
+          IF (n .eq. 6) THEN  ! User-specified lat/lon boundaries
+            call getarg(3,argv)
+            read(argv,*) wlon
+            call getarg(4,argv)
+            read(argv,*) elon
+            call getarg(5,argv)
+            read(argv,*) slat
+            call getarg(6,argv)
+            read(argv,*) nlat
+            write(*,*) 'Lon/lat boundaries: ',wlon,elon,slat,nlat
+          ELSE  ! Default lon/lat boundaries
+            slat = -90.
+            nlat = 90.
+            wlon = -180.
+            elon = 180.
+          END IF
+        ELSE
+          write(*,*) 'Usage: bufr_satwnd2ob.x gdas.satwnd.t<HH>z.
+     +<YYYYMMDD>.bufr <YYYYMMDDHH> west_lon east_lon 
+     +south_lat north_lat'
+          STOP
+        END IF
+
+C*-----------------------------------------------------------------------
+
+C*      Open the BUFR file
+        OPEN (UNIT = 11, FILE=inf, form='unformatted')
+
+        dname=' SATOB'
+        fout= "Satob"//date_tag//'.obs'
+
+C*      Open output file
+        open(iou,file=fout,status='unknown',form='formatted')
+
+        iflag = 0
+        nlev = 1
+        dumm=99999.9
+
+        isurf = 0
+        ibogus = 0
+        ter = dumm
+        dslp= dumm
+        do k=1,nz
+         date(k)='MMMMMMMMMM'
+         mins(k)='MM' 
+          pr(k)=dumm
+          zx(k)=dumm
+          tt(k)=dumm
+          td(k)=dumm
+          d(k)=dumm
+          v(k)=dumm
+        enddo
+
+C*      Identify BUFR file to the BUFRLIB software.  DX BUFR tables
+C*      are embedded within the first few messages of the BUFR file
+C*      itself, thus we logical unit for the BUFR tables file is the 
+C*      same as the BUFR file itself.
+
+        CALL OPENBF  ( 11, 'IN', 11 )
+
+C*      Specify that we would like IDATE values returned using 10 digits
+C*      (i.e. YYYYMMDDHHMM ).
+
+        CALL DATELEN  ( 10 )
+     
+        ln=0 
+
+        DO WHILE  ( .true. )
+
+C*          Read the next BUFR message.
+
+           call readns(11,csubset,idate,ierr)
+
+c            write(*,*)' idate: ',idate,'  ',csubset
+
+            IF  ( ierr .ne.  0 )  THEN
+                write(*,*) '....all records read, Exit'
+                CALL CLOSBF  ( 11 )
+                Goto 1000 
+            END IF
+
+            msgok = .true.
+
+C*	    Pass the BUFR message into the BUFRLIB software.
+
+	        CALL READERME  ( ibfmsg, 11, csubset, idate, ierrme )
+
+	        IF  ( ierrme .ne. 0 )  THEN
+		        PRINT *, 'Error reading BUFR message within READERME'
+		        msgok = .false.
+	        ELSE IF  ( csubset .ne. 'NC002007' )  THEN
+		        PRINT *, 'BUFR message is not of type WIND PROFILER'
+		        msgok = .false.
+	        END IF
+
+            DO WHILE  ( msgok )
+
+C*		Read the next data subset from the BUFR message.
+
+		    IF (IREADSB (11) .ne. 0) THEN
+		        msgok = .false.
+		    ELSE
+
+C*            At this point, we have a data subset within the
+C*            internal arrays of BUFRLIB, and we can now begin
+C*            reading actual data values:
+
+              CALL UFBINT  ( 11, r8arr, MXMN, MXLV, nlv, ostr(1))
+              CALL UFBINT  ( 11, r8arr2, MXMN, MXLV, nlv, ostr(2))
+              CALL UFBINT  ( 11, r8arr3, MXMN, MXLV, nlv, ostr(3))
+              CALL UFBINT  ( 11, r8arr4, MXMN, MXLV, nlv, ostr(4))
+
+            minu = int(r8arr3(2,1))
+            write (unit=minute, FMT='(I2)') minu
+
+            DO k=1,2
+               IF (minute (k:k) .eq. ' ') THEN
+                 minute (k:k) = '0'
+               ENDIF
+            ENDDO
+
+            DO z = 1,nlv
+              WRITE (UNIT=outstg, FMT='(I10,1x,A8, 
+     +          3(1X,F5.1),1X,A8,1X,F5.1, 
+     +          1X,F4.1,1X,F6.1,4(1x,F4.1),2(1X,F7.2),1X,F6.2,
+     +          1X,F7.1,1X,F5.1,1x,F6.2)') idate,csubset,
+     +          (r8arr(i,z), i = 1,4),(r8arr2(i,z), i = 1,5),
+     +          (r8arr3(i,z), i = 1,4),(r8arr4(i,z), i = 1,4)
+              DO y = 1,200
+               IF ( outstg (y:y) .eq. '*') THEN
+                 outstg (y:y) = 'm'
+               ENDIF
+              ENDDO
+
+              read(outstg, 21, end=1000) M10,M1,M2,M3,M4,M5,M6
+              read(minute, 22) M11
+
+21            format(A10,76X,A6,1X,A7,1X,A6,1X,A7,1X,A5,2X,A5)            
+22            format(A2)
+ 
+              iflag = iflag+1
+              j = iflag
+
+              CALL READMval(M1,lat(j))
+              CALL READMval(M2,lon(j))
+              CALL READMval(M3,tt(j))
+              CALL READMval(M4,pr(j))
+              CALL READMval(M5,d(j))
+              CALL READMval(M6,v(j))
+
+              date(j) = M10
+              mins(j) = M11
+
+              if(pr(j) .ne. 0 .and. pr(j) < 99999 ) then
+                pr(j)= pr(j)/100
+              end if
+
+            END DO           
+            END IF
+            END DO
+        END DO
+
+1000    if (iflag .ne. 0) then
+          write(iou,fmt='(a10)') date_tag
+ 
+          do k = 1,iflag
+           if(slat <= lat(k) .and. nlat >= lat(k) .and.
+     &      wlon <= lon(k) .and. elon >= lon(k)) then
+            write(iou,111)isurf,dname,dname,date(k),mins(k),
+     &        lat(k),lon(k),ter,dslp,nlev,ibogus
+            write(iou,112)pr(k),zx(k),tt(k),td(k),d(k),v(k)
+           endif
+          enddo
+111      format(i1,2(1x,a6),1x,a10,a2,4(f7.1,1x),i3,1x,i1)
+112      format(6(f7.1,1x))
+
+        endif
+
+2000    stop 99999        
+
+        END
+
+      SUBROUTINE READMval(M1,fl)
+           character*8 M1
+           dumm=99999.9
+           if(M1(1:1) ==  'm') then
+               fl = dumm
+           else
+               read(M1,*)fl
+           endif 
+
+       RETURN
+         END

--- a/src/decode_satwnd.f
+++ b/src/decode_satwnd.f
@@ -10,7 +10,7 @@
 
         PARAMETER       ( MXBF = 16000 )
 
-        parameter(iu=9,iou=10,nz=999999)
+        parameter(iu=9,iou=10,nz=9999999)
 
         dimension pr(nz),tt(nz),td(nz)
         integer  xht,nlev,i, iargc, n,minu,k
@@ -68,7 +68,7 @@ c*
             elon = 180.
           END IF
         ELSE
-          write(*,*) 'Usage: bufr_satwnd2ob.x gdas.satwnd.t<HH>z.
+          write(*,*) 'Usage: decode_satwnd.x gdas.satwnd.t<HH>z.
      +<YYYYMMDD>.bufr <YYYYMMDDHH> west_lon east_lon 
      +south_lat north_lat'
           STOP
@@ -122,7 +122,7 @@ C*      (i.e. YYYYMMDDHHMM ).
 
 C*          Read the next BUFR message.
 
-           call readns(11,csubset,idate,ierr)
+           call readns(11, csubset, idate, ierr)
 
 c            write(*,*)' idate: ',idate,'  ',csubset
 
@@ -133,18 +133,6 @@ c            write(*,*)' idate: ',idate,'  ',csubset
             END IF
 
             msgok = .true.
-
-C*	    Pass the BUFR message into the BUFRLIB software.
-
-	        CALL READERME  ( ibfmsg, 11, csubset, idate, ierrme )
-
-	        IF  ( ierrme .ne. 0 )  THEN
-		        PRINT *, 'Error reading BUFR message within READERME'
-		        msgok = .false.
-	        ELSE IF  ( csubset .ne. 'NC002007' )  THEN
-		        PRINT *, 'BUFR message is not of type WIND PROFILER'
-		        msgok = .false.
-	        END IF
 
             DO WHILE  ( msgok )
 
@@ -158,10 +146,10 @@ C*            At this point, we have a data subset within the
 C*            internal arrays of BUFRLIB, and we can now begin
 C*            reading actual data values:
 
-              CALL UFBINT  ( 11, r8arr, MXMN, MXLV, nlv, ostr(1))
-              CALL UFBINT  ( 11, r8arr2, MXMN, MXLV, nlv, ostr(2))
-              CALL UFBINT  ( 11, r8arr3, MXMN, MXLV, nlv, ostr(3))
-              CALL UFBINT  ( 11, r8arr4, MXMN, MXLV, nlv, ostr(4))
+              CALL UFBINT (11, r8arr,  MXMN, MXLV, nlv, ostr(1))
+              CALL UFBINT (11, r8arr2, MXMN, MXLV, nlv, ostr(2))
+              CALL UFBINT (11, r8arr3, MXMN, MXLV, nlv, ostr(3))
+              CALL UFBINT (11, r8arr4, MXMN, MXLV, nlv, ostr(4))
 
             minu = int(r8arr3(2,1))
             write (unit=minute, FMT='(I2)') minu
@@ -184,7 +172,7 @@ C*            reading actual data values:
                  outstg (y:y) = 'm'
                ENDIF
               ENDDO
-
+              
               read(outstg, 21, end=1000) M10,M1,M2,M3,M4,M5,M6
               read(minute, 22) M11
 
@@ -194,12 +182,12 @@ C*            reading actual data values:
               iflag = iflag+1
               j = iflag
 
-              CALL READMval(M1,lat(j))
-              CALL READMval(M2,lon(j))
-              CALL READMval(M3,tt(j))
-              CALL READMval(M4,pr(j))
-              CALL READMval(M5,d(j))
-              CALL READMval(M6,v(j))
+              CALL READMval(M1, lat(j))
+              CALL READMval(M2, lon(j))
+              CALL READMval(M3, tt(j))
+              CALL READMval(M4, pr(j))
+              CALL READMval(M5, d(j))
+              CALL READMval(M6, v(j))
 
               date(j) = M10
               mins(j) = M11

--- a/src/decode_satwnd.f
+++ b/src/decode_satwnd.f
@@ -35,7 +35,7 @@
 
         LOGICAL         msgok
 
-        EQUIVALENCE     ( cbfmsg (1), ibfmsg (1) )
+        EQUIVALENCE     ( cbfmsg (1:4), ibfmsg (1) )
 
         ostr(1)='SAID GCLONG SCLF RPID'
         ostr(2)='SIDP SWCM YEAR MNTH DAYS'

--- a/src/runob2lit_imd_obs.f
+++ b/src/runob2lit_imd_obs.f
@@ -48,33 +48,33 @@
 
 c*      write(*,*)'give the filename for datafile list :'
 c*	read(*,fmt='(a30)')fn
-	open(1,file=fn,form='formatted',status='old')
 
-	m = iunit
-	do i=1,10
-      read(1,fmt='(a30)',end=222)fin(i)
-	open(m,file=fin(i),status='old',form='formatted')
-	m = m + 1
-	enddo
+	  open(1,file=fn,form='formatted',status='old')
 
-c*222   write(*,*)'What is time tag (YYYY-MM-DD_HH): '
+	  m = iunit
+	  do i=1,10
+        read(1,fmt='(a30)',end=222) fin(i)
+	    open(m,file=fin(i),status='old',form='formatted')
+	    m = m + 1
+	  enddo
+
+c*222   write(*,*)'Enter timestamp (YYYY-MM-DD_HH): '
 c*      read(*,fmt='(a13)')time_tag
 
-222      fout1 = 'OBS:'//time_tag
+222   fout1 = 'OBS:'//time_tag
       fout2 = 'SURFACE_OBS:'//time_tag
-	open(iounit1,file=fout1,status='unknown')
-	open(iounit2,file=fout2,status='unknown')
-!
-!  start of file reading loop
-!
+	  open(iounit1,file=fout1,status='unknown')
+	  open(iounit2,file=fout2,status='unknown')
+
+c-----7---------------------------------------------------------------72
+c  start of file reading loop
       i = 1
 
       do 333 iu=iunit,m-1
-      read(iu,fmt='(i10)') mdatea
-!
-!  reading a file in the list
+        write(*,*) "reading file: ", fin(i)
+        read(iu,fmt='(i10)') mdatea
 
-
+c-----7---------------------------------------------------------------72
       do 444 iter =1,99999
 
       call miss(kx,p,z,t,td,spd,dir,slp,ter,dname,staid)
@@ -82,14 +82,14 @@ c*      read(*,fmt='(a13)')time_tag
      & xlat,xlon,dname,staid,bogus,iflag,mdate)
       call wmo_codename(isurf,dname,codestr) 
       stndesc = ' '//staid//'     get data information here.  ' 
-	if (iflag .eq. 0)then
+	  if (iflag .eq. 0)then
         write(*,111)fin(i)
 111   format('finished file : ',a30)
         i=i+1
         goto 333
-        endif
+      endif
 
-! Set desired area
+c Set desired area
 
       if(xlat .ge. -90.0 .and. xlat .le. 90.0 ) then
       if(xlon .ge. -180.0 .and. xlon .le. 180.0 ) then 
@@ -122,30 +122,34 @@ c*      read(*,fmt='(a13)')time_tag
 
 20    stop 99999
       end
-!
-!  Subroutine to fill -888888. in place of missing data
-!
+
+c-----7---------------------------------------------------------------72
+c  Subroutine to fill -888888. in place of missing data
+
       subroutine miss(kx,p,z,t,td,spd,dir,slp,ter,dname,staid)
       real p(kx),z(kx),t(kx),td(kx),spd(kx),dir(kx)
       character*6 dname,staid
 
       do k=1,kx
-      p(k)=-888888.
-      z(k)=-888888.
-      t(k)=-888888.
-      td(k)=-888888.
-      spd(k)=-888888.
-      dir(k)=-888888.
+        p(k)=-888888.
+        z(k)=-888888.
+        t(k)=-888888.
+        td(k)=-888888.
+        spd(k)=-888888.
+        dir(k)=-888888.
       enddo
+
       slp=-888888.
       ter=-888888.
       dname = '99001 '
       staid = '99001 '
+
       return
       end
-!
-! subroutine to read data from file unit
-!
+
+c-----7---------------------------------------------------------------72
+c subroutine to read data from file unit
+
       subroutine getdat(iunit,isurf,nlev,p,z,t,td,spd,dir,slp,ter,
      &  xlat,xlon,dname,staid,bogus,iflag,mdate)
 
@@ -161,63 +165,76 @@ c*      read(*,fmt='(a13)')time_tag
 
       read(iunit,113,end=1000)isurf,dname,staid,mdate,xlat,
      &     xlon,xter,xslp,nlev,ibogus
-113    format(i1,1x,a6,1x,a6,1x,a12,4(f7.1,1x),i3,1x,i1)
+113   format(i1,1x,a6,1x,a6,1x,a12,4(f7.1,1x),i3,1x,i1)
+
       if (xter .ne. dmiss) ter = xter
       if (xslp .ne. dmiss) slp = xslp*100.
-
       if(ibogus.eq.0) bogus=.FALSE.
 
-      if (isurf .eq. 1)then
+      if (isurf .eq. 1) then
         do kk=1,nlev
-
           read(iunit,114,end=1000) px(kk),zx(kk),tx(kk),tdx(kk),
      &    dirx(kk),spdx(kk)
 
           if (px(kk) .ne. dmiss) p(kk) = px(kk)*100.
-     
-	  if (zx(kk) .ne. dmiss) z(kk) = zx(kk)
-
-	  if (tx(kk) .ne. dmiss) t(kk) = tx(kk)
-  
-          if (tdx(kk) .ne. dmiss) td(kk) = tdx(kk) 
-
-	  if (dirx(kk) .ne. dmiss) dir(kk) = dirx(kk)
-
-	  if (spdx(kk) .ne. dmiss) spd(kk) = spdx(kk)
-
+	      if (zx(kk) .ne. dmiss) z(kk) = zx(kk)
+	      if (tx(kk) .ne. dmiss) t(kk) = tx(kk)
+          if (tdx(kk) .ne. dmiss) td(kk) = tdx(kk)
+	      if (dirx(kk) .ne. dmiss) dir(kk) = dirx(kk)
+	      if (spdx(kk) .ne. dmiss) spd(kk) = spdx(kk)
         enddo
-
       else
-
-	do kk=1,nlev
-
-	  read(iunit,114,end=1000) px(kk),zx(kk),tx(kk),tdx(kk),
-     &  dirx(kk),spdx(kk)
+	    do kk=1,nlev
+	      read(iunit,114,end=1000) px(kk),zx(kk),tx(kk),tdx(kk),
+     &       dirx(kk),spdx(kk)
           
-        if (px(kk) .ne. dmiss) p(kk) = px(kk)*100.
-
-	  if (zx(kk) .ne. dmiss) z(kk) = zx(kk)
-
-	  if (tx(kk) .ne. dmiss) t(kk) = tx(kk)
-
+          if (px(kk) .ne. dmiss) p(kk) = px(kk)*100.
+	      if (zx(kk) .ne. dmiss) z(kk) = zx(kk)
+	      if (tx(kk) .ne. dmiss) t(kk) = tx(kk)
           if (tdx(kk) .ne. dmiss) td(kk) = tdx(kk) 
-
-	  if (dirx(kk) .ne. dmiss) dir(kk) = dirx(kk)
-
-	  if (spdx(kk) .ne. dmiss) spd(kk) = spdx(kk)
-
-	enddo
-
+	      if (dirx(kk) .ne. dmiss) dir(kk) = dirx(kk)
+	      if (spdx(kk) .ne. dmiss) spd(kk) = spdx(kk)
+	    enddo
       endif
 
-	iflag = 1
-	goto 2000
+	  iflag = 1
+	  goto 2000
 
-114    format(6(f7.1,1x))
-1000	iflag = 0
+114   format(6(f7.1,1x))
+1000  iflag = 0
+
 2000  return
+
       end
-!   Subroutine to put WMO code for each type of data
+
+c-----7---------------------------------------------------------------72
+c   Subroutine to put WMO code for each type of data
+c
+c   Given the WMO code fm, return the observation platform type and increment
+c   the corresponding counter if present.
+c
+c Returned platforms are reduced to 13 output classes:
+c
+c   Name    WMO Codes     WMO Code names
+c   synop    12,14       'SYNOP','SYNOP MOBIL'
+c   ship     13          'SHIP'
+c   metar    15,16       'METAR','SPECI'
+c   buoy     18          'BUOY'
+c   pilot    32,33,34    'PILOT','PILOT SHIP','PILOT MOBIL'
+c   sound    35,36,37,38 'TEMP','TEMP SHIP, 'TEMP DROP','TEMP MOBIL'
+c   amdar    42          'AMDAR'
+c   satem    86          'SATEM'
+c   satob    88          'SATOB'
+c   airep    96,97       'AIREP'
+c   gpspw    111         'GPSPW'
+c   ssmt1    121         'SSMT1'
+c   ssmt2    122         'SSMT2'
+c   ssmi     125,126     'SSMI'
+c   tovs     131         'TOVS'
+c   qscat    281         'Quikscat'
+c   profl    132         'Profilers'
+c   other Any other code 'UNKNOWN'
+c-----7---------------------------------------------------------------72
       
       subroutine wmo_codename(isurf,dname,codestr) 
       
@@ -259,38 +276,13 @@ c*      read(*,fmt='(a13)')time_tag
       endif
 
       endif
-!------------------------------------------------------------------------------!
-! Given the WMO code fm, return the observation platform type and increment
-! the corresponding counter if present.
-!
-! Returned platforms are reduced to 13 output classes:
-!
-!   Name    WMO Codes     WMO Code names
-!   synop    12,14       'SYNOP','SYNOP MOBIL'
-!   ship     13          'SHIP'
-!   metar    15,16       'METAR','SPECI'
-!   buoy     18          'BUOY'
-!   pilot    32,33,34    'PILOT','PILOT SHIP','PILOT MOBIL'
-!   sound    35,36,37,38 'TEMP','TEMP SHIP, 'TEMP DROP','TEMP MOBIL'
-!   amdar    42          'AMDAR'
-!   satem    86          'SATEM'
-!   satob    88          'SATOB'
-!   airep    96,97       'AIREP'
-!   gpspw    111         'GPSPW'
-!   ssmt1    121         'SSMT1'
-!   ssmt2    122         'SSMT2'
-!   ssmi     125,126     'SSMI'
-!   tovs     131         'TOVS'
-!   qscat    281         'Quikscat'
-!   profl    132         'Profilers'
-!   other Any other code 'UNKNOWN'
-!------------------------------------------------------------------------------!
+
       return
       end
 
-!
-!  Subroutine to write data in a specified format for little_r
-!
+c-----7---------------------------------------------------------------72
+c  Subroutine to write data in a specified format for little_r
+
       SUBROUTINE write_obs ( p , z , t , td , spd , dir , 
      &                      slp , ter , xlat , xlon , mdate , kx , 
      & string1 , string2 , string3 , string4 , bogus , iseq_num ,
@@ -306,10 +298,9 @@ c*      read(*,fmt='(a13)')time_tag
       CHARACTER *22  meas_format 
       CHARACTER *14  end_format
       logical bogus
-! changed Osuri
+c changed Osuri
       iseq_num =0      
-! changed Osuri end
-
+c changed Osuri end
 
       rpt_format =  ' ( 2f20.5 , 2a40 , '
      &             // ' 2a40 , 1f20.5 , 5i10 , 3L10 , '
@@ -317,11 +308,11 @@ c*      read(*,fmt='(a13)')time_tag
       meas_format =  ' ( 10( f13.5 , i7 ) ) '
       end_format = ' ( 3 ( i7 ) ) ' 
       write (date_char(7:18),fmt='(a12)') mdate
-!     if (mdate/1000000 .GT. 70 ) then
-!        date_char(7:8)='19'
-!     else
-!        date_char(7:8)='20'
-!     endif
+c     if (mdate/1000000 .GT. 70 ) then
+c        date_char(7:8)='19'
+c     else
+c        date_char(7:8)='20'
+c     endif
       date_char(19:20)='00'
       date_char(1:6)='      '
 

--- a/src/runob2lit_imd_obs.f
+++ b/src/runob2lit_imd_obs.f
@@ -38,6 +38,7 @@
       character*13 time_tag
       character*40 fn,stndesc,codestr
       data iunit,iounit1,iounit2/114,150,151/
+      parameter (maxob=9999999)
 
       n = iargc()
 
@@ -75,7 +76,7 @@ c  start of file reading loop
         read(iu,fmt='(i10)') mdatea
 
 c-----7---------------------------------------------------------------72
-      do 444 iter =1,99999
+      do 444 iter=1,maxob
 
       call miss(kx,p,z,t,td,spd,dir,slp,ter,dname,staid)
       call getdat(iu,isurf,nlev,p,z,t,td,spd,dir,slp,ter,


### PR DESCRIPTION
Increased the array size declarations for observational parameter arrays.  The arrays were not large enough to accommodate all the observations in the BUFR messages, which was resulting in runtime memory errors.